### PR TITLE
Fix missing <array> include.

### DIFF
--- a/wordlebot.cpp
+++ b/wordlebot.cpp
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <thread>
 #include <chrono>
+#include <array>
 
 enum GuessResult {
     DOES_NOT_EXIST = 0,


### PR DESCRIPTION
Adds <array> include, otherwise it doesn't compile in VS2019.